### PR TITLE
Add takeWhile operator import for downstream clients

### DIFF
--- a/src/app/public/modules/flyout/flyout.service.ts
+++ b/src/app/public/modules/flyout/flyout.service.ts
@@ -16,6 +16,7 @@ import {
 } from 'rxjs';
 
 import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/takeWhile';
 
 import {
   SkyDynamicComponentService,

--- a/src/app/public/modules/flyout/flyout.service.ts
+++ b/src/app/public/modules/flyout/flyout.service.ts
@@ -13,10 +13,13 @@ import {
 import {
   Observable,
   Subject
+
 } from 'rxjs';
 
 import 'rxjs/add/operator/take';
 import 'rxjs/add/operator/takeWhile';
+import 'rxjs/add/operator/takeUntil';
+import 'rxjs/add/observable/fromEvent';
 
 import {
   SkyDynamicComponentService,

--- a/src/app/public/modules/flyout/flyout.service.ts
+++ b/src/app/public/modules/flyout/flyout.service.ts
@@ -13,7 +13,6 @@ import {
 import {
   Observable,
   Subject
-
 } from 'rxjs';
 
 import 'rxjs/add/operator/take';


### PR DESCRIPTION
We ran into an issue today with our supportal spa, which is on `skyux3`, failed to open the flyover  and displayed the following error due to some sort of dependency issue. As discussed in BB slack, we found that including this import fixed it.

original error:
```
AppNavComponent.html:14 ERROR TypeError: this.router.events.takeWhile is not a function
    at SkyFlyoutService../node_modules/@skyux/flyout/modules/flyout/flyout.service.js.SkyFlyoutService.open (flyout.service.js:35)
```

cc: @Blackbaud-PaulCrowder 
