### PR TITLE
Fix flyout to listen for message stream events as long as it is active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5730,6 +5730,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -8402,6 +8412,13 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filelist": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -10968,6 +10985,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.2.0",
@@ -16216,7 +16240,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/projects/flyout/src/modules/flyout/flyout.component.spec.ts
+++ b/projects/flyout/src/modules/flyout/flyout.component.spec.ts
@@ -100,6 +100,9 @@ describe('Flyout component', () => {
     tick();
     fixture.detectChanges();
     tick();
+    // Second detection allows for the flyout service to remove the flyout host when appropriate
+    fixture.detectChanges();
+    tick();
   }
 
   function makeEvent(eventType: string, evtObj: any): void {
@@ -1310,6 +1313,25 @@ describe('Flyout component', () => {
       expect(iteratorButtons[1].disabled).toBeFalsy();
       expect(flyout.iteratorNextButtonDisabled).toEqual(false);
       expect(flyout.iteratorPreviousButtonDisabled).toEqual(false);
+    }));
+
+    it('should remove host if a non-close message stream event was fired before close - added due to bug', fakeAsync(() => {
+      const flyout = openFlyout({
+        showIterator: true,
+      });
+
+      flyout.iteratorPreviousButtonDisabled = true;
+      flyout.iteratorNextButtonDisabled = true;
+      fixture.detectChanges();
+
+      const iteratorButtons = getIteratorButtons();
+      expect(iteratorButtons.length).toEqual(2);
+      expect(iteratorButtons[0].disabled).toBeTruthy();
+      expect(iteratorButtons[1].disabled).toBeTruthy();
+
+      closeFlyout();
+
+      expect(getFlyoutHostElement()).toBeNull();
     }));
   });
 

--- a/projects/flyout/src/modules/flyout/flyout.component.spec.ts
+++ b/projects/flyout/src/modules/flyout/flyout.component.spec.ts
@@ -1020,7 +1020,7 @@ describe('Flyout component', () => {
       getPermalinkButtonElement().click();
       const navigation = TestBed.inject(Router).getCurrentNavigation();
       expect(navigation.extras.state.foo).toEqual('bar');
-      tick(500);
+      tick();
     }));
 
     it('should navigate to a URL when clicking on the permalink button', fakeAsync(() => {

--- a/projects/flyout/src/modules/flyout/flyout.component.spec.ts
+++ b/projects/flyout/src/modules/flyout/flyout.component.spec.ts
@@ -1020,7 +1020,7 @@ describe('Flyout component', () => {
       getPermalinkButtonElement().click();
       const navigation = TestBed.inject(Router).getCurrentNavigation();
       expect(navigation.extras.state.foo).toEqual('bar');
-      tick();
+      tick(500);
     }));
 
     it('should navigate to a URL when clicking on the permalink button', fakeAsync(() => {

--- a/projects/flyout/src/modules/flyout/flyout.service.spec.ts
+++ b/projects/flyout/src/modules/flyout/flyout.service.spec.ts
@@ -97,7 +97,7 @@ describe('Flyout service', () => {
 
     router.navigate(['/']);
 
-    tick(500);
+    tick();
     applicationRef.tick();
 
     expect(closeSpy).toHaveBeenCalled();
@@ -116,7 +116,7 @@ describe('Flyout service', () => {
 
     router.navigate(['/']);
 
-    tick(500);
+    tick();
     applicationRef.tick();
 
     expect(removeComponentSpy).toHaveBeenCalledTimes(1);
@@ -137,11 +137,6 @@ describe('Flyout service', () => {
     router.navigate(['/']);
 
     tick();
-    applicationRef.tick();
-
-    expect(removeComponentSpy).not.toHaveBeenCalled();
-
-    tick(500);
     applicationRef.tick();
 
     expect(removeComponentSpy).toHaveBeenCalled();

--- a/projects/flyout/src/modules/flyout/flyout.service.spec.ts
+++ b/projects/flyout/src/modules/flyout/flyout.service.spec.ts
@@ -97,7 +97,7 @@ describe('Flyout service', () => {
 
     router.navigate(['/']);
 
-    tick();
+    tick(500);
     applicationRef.tick();
 
     expect(closeSpy).toHaveBeenCalled();
@@ -116,7 +116,32 @@ describe('Flyout service', () => {
 
     router.navigate(['/']);
 
+    tick(500);
+    applicationRef.tick();
+
+    expect(removeComponentSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should remove the host when the user navigates through history if no closed event is fired in 500ms - sanity check', fakeAsync(() => {
+    service.open(SkyFlyoutHostsTestComponent);
+    const dynamicService = TestBed.inject(SkyDynamicComponentService);
+    const removeComponentSpy = spyOn(
+      dynamicService,
+      'removeComponent'
+    ).and.callThrough();
+    spyOn(service['host'].instance.messageStream, 'next').and.stub();
+
     tick();
+    applicationRef.tick();
+
+    router.navigate(['/']);
+
+    tick();
+    applicationRef.tick();
+
+    expect(removeComponentSpy).not.toHaveBeenCalled();
+
+    tick(500);
     applicationRef.tick();
 
     expect(removeComponentSpy).toHaveBeenCalled();

--- a/projects/flyout/src/modules/flyout/flyout.service.spec.ts
+++ b/projects/flyout/src/modules/flyout/flyout.service.spec.ts
@@ -92,7 +92,6 @@ describe('Flyout service', () => {
   it('should close when the user navigates through history', fakeAsync(() => {
     service.open(SkyFlyoutHostsTestComponent);
     const closeSpy = spyOn(service, 'close').and.callThrough();
-
     tick();
     applicationRef.tick();
 
@@ -102,6 +101,25 @@ describe('Flyout service', () => {
     applicationRef.tick();
 
     expect(closeSpy).toHaveBeenCalled();
+  }));
+
+  it('should remove the host after close when the user navigates through history', fakeAsync(() => {
+    service.open(SkyFlyoutHostsTestComponent);
+    const dynamicService = TestBed.inject(SkyDynamicComponentService);
+    const removeComponentSpy = spyOn(
+      dynamicService,
+      'removeComponent'
+    ).and.callThrough();
+
+    tick();
+    applicationRef.tick();
+
+    router.navigate(['/']);
+
+    tick();
+    applicationRef.tick();
+
+    expect(removeComponentSpy).toHaveBeenCalled();
   }));
 
   it('should not close on route change if it is already closed', fakeAsync(() => {

--- a/projects/flyout/src/modules/flyout/flyout.service.ts
+++ b/projects/flyout/src/modules/flyout/flyout.service.ts
@@ -166,7 +166,7 @@ export class SkyFlyoutService implements OnDestroy {
 
       this.removeAfterClosed = false;
       flyoutInstance.messageStream
-        .pipe(take(1))
+        .pipe(takeUntil(this.ngUnsubscribe))
         .subscribe((message: SkyFlyoutMessage) => {
           if (message.type === SkyFlyoutMessageType.Close) {
             this.removeAfterClosed = true;

--- a/projects/flyout/src/modules/flyout/flyout.service.ts
+++ b/projects/flyout/src/modules/flyout/flyout.service.ts
@@ -86,6 +86,13 @@ export class SkyFlyoutService implements OnDestroy {
           if (event instanceof NavigationStart) {
             this.close();
           }
+
+          // Sanity check - if the host still exists after animations should have completed - remove host
+          setTimeout(() => {
+            if (this.host) {
+              this.removeHostComponent();
+            }
+          }, 500);
         });
     }
 


### PR DESCRIPTION
What was happening here was a combination of two things

1. We were not removing the host component from the DOM because our logic to trigger this removal had a `take` of 1 on the flyout message stream. However this message stream is used for things such as disabling the iterator buttons along with closing. So in this case - the consumer was disabling the iterator buttons and then when the flyout closed the logic to remove the host was never hit as the `take(1)` had already been satisfied.
2. Our logic for closing flyouts when navigating assumed that a flyout was open if a host was open. This caused a state where because the flyout instance's `closed` event was already completed - we were assuming this would fire after the animation completed and so we were not removing the host directly. I added some sanity check logic to ensure that we remove the host now if it still exists after our animation should have finished. 